### PR TITLE
chore(renovate): group Harbor chart and app version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,14 @@
       "groupSlug": "arc"
     },
     {
+      "description": "Group Harbor updates together. The chart version and the application version pin the same image tags (see prototypes/harbor/helm/harbor.yaml), so bumping one without the other resolves to a nonexistent tag.",
+      "matchFileNames": [
+        "prototypes/harbor/**"
+      ],
+      "groupName": "harbor",
+      "groupSlug": "harbor"
+    },
+    {
       "description": "Pin latest container image tags",
       "matchDatasources": [
         "docker"

--- a/renovate.yaml
+++ b/renovate.yaml
@@ -34,6 +34,13 @@ packageRules:
       - ghcr.io/actions/actions-runner-controller-charts/**
     groupName: arc
     groupSlug: arc
+  - description: >-
+      Group Harbor updates together. The chart version and the application version pin the same image tags
+      (see prototypes/harbor/helm/harbor.yaml), so bumping one without the other resolves to a nonexistent tag.
+    matchFileNames:
+      - prototypes/harbor/**
+    groupName: harbor
+    groupSlug: harbor
   - description: Pin latest container image tags
     matchDatasources:
       - docker


### PR DESCRIPTION
**What**: Group all dependency updates under `prototypes/harbor/**` into a single Renovate PR.

**Why**: PRs #960 (chart `1.19.1` → `1.19.2`) and #895 (app `v2.15.1` → `v2.15.2`) both fail `render`, each because the other is missing. Harbor pins every image tag to `application.version` (`prototypes/harbor/helm/harbor.yaml`) so the tags match the image-puller jobs, which makes the chart version and the app version one atomic change:

- chart `1.19.2` switched `redis.internal.image.repository` to `goharbor/valkey-photon`, and `valkey-photon:v2.15.1` was never published (starts at `v2.15.2`)
- upstream published no `redis-photon:v2.15.2`, so the app bump alone breaks chart `1.19.1`

Either half alone resolves to a nonexistent tag and kbld fails.

**Notes for reviewer**: `renovate.json` is generated — `yq -P -o json renovate.yaml > renovate.json`.

The next grouped Harbor PR will still be red on its own: `prototypes/harbor/ytt/image-puller.yaml` hardcodes `redis-photon` in the image list, which Renovate does not track. That line needs to become `valkey-photon` alongside the version bumps.

Supersedes #960 and #895.